### PR TITLE
Add c dependency to oomph and ghex

### DIFF
--- a/packages/ghex/package.py
+++ b/packages/ghex/package.py
@@ -14,6 +14,7 @@ class Ghex(CMakePackage, CudaPackage, ROCmPackage):
     version("0.3.0", tag="v0.3.0", submodules=True)
     version("master", branch="master", submodules=True)
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     generator("ninja")

--- a/packages/oomph/package.py
+++ b/packages/oomph/package.py
@@ -15,6 +15,7 @@ class Oomph(CMakePackage, CudaPackage, ROCmPackage):
     version("0.1.0", sha256="0ff36db0a5f30ae1bb02f6db6d411ea72eadd89688c00f76b4e722bd5a9ba90b")
     version("main", branch="main")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build", when="+fortran-bindings")
 


### PR DESCRIPTION
While ghex and oomph don't directly use C as a CMake language, I think one of the submodules, either gtest or gridtools enable it as a language.